### PR TITLE
YEL-2786

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -14,7 +14,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "CentOS 7*",
+          "name": "CentOS Linux 7 x86_64 HVM EBS ENA 1901_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e*",
           "root-device-type": "ebs"
         },
         "owners": [

--- a/packer.json
+++ b/packer.json
@@ -14,7 +14,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "CentOS 7 x86_64*",
+          "name": "CentOS 7*",
           "root-device-type": "ebs"
         },
         "owners": [

--- a/packer.json
+++ b/packer.json
@@ -14,7 +14,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "CentOS Linux 7 x86_64 HVM*",
+          "name": "CentOS 7 x86_64*",
           "root-device-type": "ebs"
         },
         "owners": [


### PR DESCRIPTION
Use specific AMI Name wildcard, in an attempt to pick the standard (free) CentOS 7 image, rather than paying for support from "Supported Images" which we don't want/need